### PR TITLE
fix(openai/responses): forward function-call name from output_item.added

### DIFF
--- a/providers/openai_responses.go
+++ b/providers/openai_responses.go
@@ -847,6 +847,17 @@ func (p *OpenAIProvider) streamWithResponsesAPI(ctx context.Context, req *OpenAI
 	}, nil
 }
 
+// indexFromOutput maps a Responses API output_index onto the flat tool-call
+// Index the stream accumulator keys by. Responses tool-call events carry their
+// slot in output_index (not index), so without this every parallel function
+// call defaults to index 0 and the accumulator merges them.
+func indexFromOutput(outputIndex *int) int {
+	if outputIndex != nil {
+		return *outputIndex
+	}
+	return 0
+}
+
 // ==================== Responses API Stream Reader ====================
 
 // responsesAPIStreamReader implements streaming for OpenAI /responses endpoint
@@ -1058,6 +1069,7 @@ func (r *responsesAPIStreamReader) Next() (*StreamChunk, error) {
 			}
 			streamChunk.Type = "tool_call_delta"
 			streamChunk.ToolCallDelta = &ToolCallDelta{
+				Index:          indexFromOutput(delta.OutputIndex),
 				ID:             delta.ItemID,
 				Type:           "function",
 				ArgumentsDelta: delta.Delta,
@@ -1087,6 +1099,7 @@ func (r *responsesAPIStreamReader) Next() (*StreamChunk, error) {
 			}
 			seenDelta := done.ItemID != "" && r.toolCallSeenMap[done.ItemID]
 			streamChunk.ToolCallDelta = &ToolCallDelta{
+				Index:        indexFromOutput(done.OutputIndex),
 				ID:           done.ItemID,
 				Type:         "function",
 				FunctionName: done.Name,
@@ -1138,6 +1151,7 @@ func (r *responsesAPIStreamReader) Next() (*StreamChunk, error) {
 			if item.Item.Type == "function_call" {
 				streamChunk.Type = "tool_call_delta"
 				streamChunk.ToolCallDelta = &ToolCallDelta{
+					Index:        indexFromOutput(item.OutputIndex),
 					ID:           item.Item.ID,
 					Type:         "function",
 					FunctionName: item.Item.Name,

--- a/providers/openai_responses.go
+++ b/providers/openai_responses.go
@@ -1114,6 +1114,12 @@ func (r *responsesAPIStreamReader) Next() (*StreamChunk, error) {
 					Type   string `json:"type"`
 					Role   string `json:"role,omitempty"`
 					Status string `json:"status,omitempty"`
+					// function_call items carry the tool NAME here. The
+					// Responses API sends the name only at call start (the
+					// argument-delta events carry args but no name), so it must
+					// be surfaced now or it is lost.
+					Name   string `json:"name,omitempty"`
+					CallID string `json:"call_id,omitempty"`
 				} `json:"item"`
 				OutputIndex    *int `json:"output_index,omitempty"`
 				SequenceNumber int  `json:"sequence_number,omitempty"`
@@ -1123,6 +1129,24 @@ func (r *responsesAPIStreamReader) Next() (*StreamChunk, error) {
 			}
 			if !r.shouldEmit(&item.SequenceNumber) {
 				continue
+			}
+			// A function_call item opens a tool call. Emit a tool_call_delta
+			// carrying the name at call start, mirroring the chat-completions
+			// stream (whose first tool_call delta carries the name). Without
+			// this the assembled tool call has full args but an empty name,
+			// because the name never reaches a delta the host accumulates.
+			if item.Item.Type == "function_call" {
+				streamChunk.Type = "tool_call_delta"
+				streamChunk.ToolCallDelta = &ToolCallDelta{
+					ID:           item.Item.ID,
+					Type:         "function",
+					FunctionName: item.Item.Name,
+					OutputIndex:  item.OutputIndex,
+					ItemID:       item.Item.ID,
+				}
+				streamChunk.ItemID = item.Item.ID
+				streamChunk.OutputIndex = item.OutputIndex
+				return streamChunk, nil
 			}
 			streamChunk.Type = "output_item_added"
 			streamChunk.ItemID = item.Item.ID

--- a/providers/openai_responses_test.go
+++ b/providers/openai_responses_test.go
@@ -1,7 +1,9 @@
 package providers
 
 import (
+	"bufio"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -222,5 +224,63 @@ func TestResponsesRejectsConversationWithPreviousResponseID(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected mutual exclusion error")
+	}
+}
+
+// Regression: OpenAI's Responses API (gpt-5*) delivers a function call's NAME
+// only in response.output_item.added; the argument-delta events carry args but
+// no name. The reader must forward that name as a tool_call_delta at call start
+// (mirroring the chat-completions stream), so downstream accumulation captures
+// it. Otherwise the assembled tool call has full args and an empty name, and
+// the host dispatches `tool "" not found` / OpenAI later rejects the history
+// with "function name is required".
+func TestResponsesStreamForwardsFunctionNameAtCallStart(t *testing.T) {
+	sse := strings.Join([]string{
+		`event: response.output_item.added`,
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","status":"in_progress","name":"get_weather","call_id":"call_1","arguments":""},"sequence_number":1}`,
+		``,
+		`event: response.function_call_arguments.delta`,
+		`data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"{\"city\":","sequence_number":2}`,
+		``,
+		`event: response.function_call_arguments.delta`,
+		`data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"\"SF\"}","sequence_number":3}`,
+		``,
+		`event: response.function_call_arguments.done`,
+		`data: {"type":"response.function_call_arguments.done","item_id":"fc_1","output_index":0,"name":"get_weather","arguments":"{\"city\":\"SF\"}","sequence_number":4}`,
+		``,
+		`event: response.completed`,
+		`data: {"type":"response.completed","sequence_number":5,"response":{"id":"resp_1","status":"completed"}}`,
+		``,
+	}, "\n")
+
+	r := &responsesAPIStreamReader{
+		scanner:         bufio.NewScanner(strings.NewReader(sse)),
+		provider:        "openai",
+		model:           "gpt-5.4-mini",
+		toolCallSeenMap: make(map[string]bool),
+	}
+
+	var startName, args string
+	for {
+		c, err := r.Next()
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if c.Done {
+			break
+		}
+		if c.ToolCallDelta != nil {
+			if c.Type == "tool_call_delta" && c.ToolCallDelta.FunctionName != "" && startName == "" {
+				startName = c.ToolCallDelta.FunctionName
+			}
+			args += c.ToolCallDelta.ArgumentsDelta
+		}
+	}
+
+	if startName != "get_weather" {
+		t.Fatalf("expected a tool_call_delta carrying the function name at call start, got %q (the Responses API only sends the name in output_item.added; it must be forwarded so downstream captures it)", startName)
+	}
+	if args != `{"city":"SF"}` {
+		t.Fatalf("arguments = %q, want the accumulated JSON", args)
 	}
 }

--- a/providers/openai_responses_test.go
+++ b/providers/openai_responses_test.go
@@ -284,3 +284,61 @@ func TestResponsesStreamForwardsFunctionNameAtCallStart(t *testing.T) {
 		t.Fatalf("arguments = %q, want the accumulated JSON", args)
 	}
 }
+
+// Regression: the stream accumulator keys tool calls by ToolCallDelta.Index.
+// The Responses API carries the slot in output_index, so the reader must map
+// output_index -> Index on every tool-call event; otherwise parallel function
+// calls all default to index 0 and get merged. (voocel/litellm#4 review.)
+func TestResponsesStreamMapsOutputIndexToIndex(t *testing.T) {
+	sse := strings.Join([]string{
+		`event: response.output_item.added`,
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_0","type":"function_call","name":"tool_a","call_id":"call_0","arguments":""},"sequence_number":1}`,
+		``,
+		`event: response.output_item.added`,
+		`data: {"type":"response.output_item.added","output_index":1,"item":{"id":"fc_1","type":"function_call","name":"tool_b","call_id":"call_1","arguments":""},"sequence_number":2}`,
+		``,
+		`event: response.function_call_arguments.delta`,
+		`data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":1,"delta":"{}","sequence_number":3}`,
+		``,
+		`event: response.function_call_arguments.done`,
+		`data: {"type":"response.function_call_arguments.done","item_id":"fc_1","output_index":1,"name":"tool_b","arguments":"{}","sequence_number":4}`,
+		``,
+		`event: response.completed`,
+		`data: {"type":"response.completed","sequence_number":5,"response":{"id":"resp_1","status":"completed"}}`,
+		``,
+	}, "\n")
+
+	r := &responsesAPIStreamReader{
+		scanner:         bufio.NewScanner(strings.NewReader(sse)),
+		provider:        "openai",
+		model:           "gpt-5.4-mini",
+		toolCallSeenMap: make(map[string]bool),
+	}
+
+	// Map each tool call's item id to the Index values its events carried.
+	idxByItem := map[string]int{}
+	for {
+		c, err := r.Next()
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if c.Done {
+			break
+		}
+		d := c.ToolCallDelta
+		if d == nil || d.ItemID == "" {
+			continue
+		}
+		if prev, ok := idxByItem[d.ItemID]; ok && prev != d.Index {
+			t.Fatalf("item %s saw inconsistent Index %d vs %d", d.ItemID, prev, d.Index)
+		}
+		idxByItem[d.ItemID] = d.Index
+	}
+
+	if idxByItem["fc_0"] != 0 {
+		t.Fatalf("fc_0 Index = %d, want 0", idxByItem["fc_0"])
+	}
+	if idxByItem["fc_1"] != 1 {
+		t.Fatalf("fc_1 Index = %d, want 1 (output_index must map to Index so the accumulator keeps parallel calls separate)", idxByItem["fc_1"])
+	}
+}


### PR DESCRIPTION
## Problem

gpt-5* models route to the Responses API. There the function call's name arrives only in `response.output_item.added`. The `response.function_call_arguments.delta` events carry arguments but no name. The stream reader parsed `id/type/role/status` from `output_item.added` and dropped `name`, surfacing it only later in `response.function_call_arguments.done` (emitted as `tool_call_end`).

Hosts that assemble the tool call from the delta stream end up with full arguments and an empty name. Downstream that shows up as:

- dispatch failing with `tool "" not found`, and
- the next request rejected by OpenAI with `messages[N].tool_calls[0]: function name is required`.

Chat completions don't hit this. Their first `tool_call` delta already carries the name.

## Fix

When `output_item.added` opens a `function_call` item, forward its `name` as a `tool_call_delta` at call start. Mirrors the chat-completions stream shape, so existing accumulation picks up the name with no host-side changes.

## Test

Added a regression test that drives the function-call SSE (`output_item.added` then `function_call_arguments.delta` then `.done`) and asserts the name arrives in a start delta. Red before, green after. Full suite stays green.
