### PR TITLE
fix(anthropic): don't send temperature and top_p together (Claude 4 returns 400)

### DIFF
--- a/providers/anthropic.go
+++ b/providers/anthropic.go
@@ -221,6 +221,14 @@ func (p *AnthropicProvider) buildHTTPRequest(ctx context.Context, req *Request, 
 		OutputConfig:  outputConfig,
 	}
 
+	// Claude models reject a request that specifies both temperature and top_p
+	// ("`temperature` and `top_p` cannot both be specified for this model").
+	// The client backfills top_p by default, so prefer temperature and drop
+	// top_p when both are present.
+	if anthropicReq.Temperature != nil {
+		anthropicReq.TopP = nil
+	}
+
 	if p.deepSeekCompat {
 		anthropicReq.Thinking = resolveDeepSeekAnthropicThinking(req)
 		if effort := deepSeekThinkingEffortFromRequest(req); effort != "" {

--- a/providers/anthropic_topp_test.go
+++ b/providers/anthropic_topp_test.go
@@ -1,0 +1,72 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+)
+
+// Claude models reject a request that specifies both temperature and top_p
+// ("`temperature` and `top_p` cannot both be specified for this model").
+// The client backfills top_p by default, so when a caller (or a default) sets
+// temperature, the Anthropic provider must not also send top_p.
+func TestAnthropicBuildHTTPRequest_DropsTopPWhenTemperatureSet(t *testing.T) {
+	p := NewAnthropic(ProviderConfig{APIKey: "test-key"})
+	temp, topP := 0.7, 0.9
+	req := &Request{
+		Model:       "claude-sonnet-4-6",
+		Messages:    []Message{{Role: "user", Content: "hi"}},
+		Temperature: &temp,
+		TopP:        &topP,
+	}
+
+	httpReq, err := p.buildHTTPRequest(context.Background(), req, false)
+	if err != nil {
+		t.Fatalf("buildHTTPRequest: %v", err)
+	}
+	body, err := io.ReadAll(httpReq.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+
+	if _, ok := got["top_p"]; ok {
+		t.Errorf("top_p must be omitted when temperature is set; body=%s", body)
+	}
+	if _, ok := got["temperature"]; !ok {
+		t.Errorf("temperature should be present; body=%s", body)
+	}
+}
+
+// When only top_p is set, it must still be sent (temperature is the one dropped
+// only when both are present).
+func TestAnthropicBuildHTTPRequest_KeepsTopPWhenTemperatureUnset(t *testing.T) {
+	p := NewAnthropic(ProviderConfig{APIKey: "test-key"})
+	topP := 0.9
+	req := &Request{
+		Model:    "claude-sonnet-4-6",
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		TopP:     &topP,
+	}
+
+	httpReq, err := p.buildHTTPRequest(context.Background(), req, false)
+	if err != nil {
+		t.Fatalf("buildHTTPRequest: %v", err)
+	}
+	body, err := io.ReadAll(httpReq.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+
+	if _, ok := got["top_p"]; !ok {
+		t.Errorf("top_p should be present when temperature is unset; body=%s", body)
+	}
+}


### PR DESCRIPTION
Claude 4 models reject a request that specifies both `temperature` and `top_p`:

> 400 invalid_request_error: `temperature` and `top_p` cannot both be specified for this model. Please use only one.

The client backfills `top_p` by default (`client_runtime.go` `applyDefaults`), so any caller that sets `temperature` and leaves `top_p` nil ends up sending both, and every Claude 4 request 400s. `providers/anthropic.go` now drops `top_p` when `temperature` is set (prefers temperature). Covered by `providers/anthropic_topp_test.go`.

Repro: set `Temperature` on a Request to a `claude-*` model, leave `TopP` nil. The default backfill adds `top_p=1.0` and the request fails.

The fix could alternatively live in `applyDefaults` (skip the `top_p` backfill for the anthropic provider), but the provider is the authority on what Anthropic accepts, so I put it there. Happy to move it if you'd prefer.