### PR TITLE
fix(anthropic): preserve empty tool input

### DIFF
--- a/provider/anthropic/request.go
+++ b/provider/anthropic/request.go
@@ -39,7 +39,7 @@ type anthropicContent struct {
 	ID           string                 `json:"id,omitempty"`
 	ToolUseID    string                 `json:"tool_use_id,omitempty"`
 	Name         string                 `json:"name,omitempty"`
-	Input        map[string]any         `json:"input,omitempty"`
+	Input        *map[string]any        `json:"input,omitempty"`
 	Content      any                    `json:"content,omitempty"`
 	ToolName     string                 `json:"tool_name,omitempty"`
 	IsError      bool                   `json:"is_error,omitempty"`
@@ -576,17 +576,20 @@ func convertBlocks(blocks []litellm.Block) ([]anthropicContent, error) {
 				out = append(out, anthropicContent{Type: "thinking", Thinking: b.Text, Signature: b.Signature, CacheControl: cache})
 			}
 		case litellm.ToolUseBlock:
-			var input map[string]any
+			input := map[string]any{}
 			if len(b.Arguments) > 0 {
 				if err := json.Unmarshal(b.Arguments, &input); err != nil {
 					return nil, fmt.Errorf("anthropic: tool use %q arguments must be object: %w", b.ID, err)
 				}
 			}
+			if input == nil {
+				input = map[string]any{}
+			}
 			cache, err := cacheControl(b.Cache)
 			if err != nil {
 				return nil, err
 			}
-			out = append(out, anthropicContent{Type: "tool_use", ID: b.ID, Name: b.Name, Input: input, CacheControl: cache})
+			out = append(out, anthropicContent{Type: "tool_use", ID: b.ID, Name: b.Name, Input: &input, CacheControl: cache})
 		case litellm.ToolResultBlock:
 			content, err := convertToolResultContent(b.Content)
 			if err != nil {

--- a/provider/anthropic/request_test.go
+++ b/provider/anthropic/request_test.go
@@ -607,11 +607,12 @@ func TestConvertResponseRejectsNil(t *testing.T) {
 }
 
 func TestResponseBlocksRoundTripBackIntoAssistantMessage(t *testing.T) {
+	input := map[string]any{"q": "x"}
 	resp, err := convertResponse(&anthropicResponse{
 		Model: "claude",
 		Content: []anthropicContent{
 			{Type: "thinking", Thinking: "Need lookup.", Signature: "sig-thinking"},
-			{Type: "tool_use", ID: "toolu_1", Name: "lookup", Input: map[string]any{"q": "x"}},
+			{Type: "tool_use", ID: "toolu_1", Name: "lookup", Input: &input},
 		},
 	}, "fallback")
 	if err != nil {
@@ -948,6 +949,65 @@ func TestBuildRequestMapsJSONSchemaResponseFormat(t *testing.T) {
 	}, false)
 	if err == nil || !strings.Contains(err.Error(), "json_object is not supported") {
 		t.Fatalf("expected json_object error, got %v", err)
+	}
+}
+
+func TestBuildRequestKeepsEmptyToolUseInput(t *testing.T) {
+	provider, err := New(Config{APIKey: "test"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	maxTokens := 1024
+	cases := []struct {
+		name string
+		call litellm.ToolUseBlock
+	}{
+		{
+			name: "missing arguments",
+			call: litellm.ToolUseBlock{ID: "toolu_empty", Name: "novel_context"},
+		},
+		{
+			name: "empty object arguments",
+			call: litellm.ToolUseBlock{
+				ID:        "toolu_empty",
+				Name:      "novel_context",
+				Arguments: litellm.MustJSONRaw(map[string]any{}),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wire, _, err := provider.buildRequest(&litellm.Request{
+				Model:     "claude",
+				MaxTokens: &maxTokens,
+				Messages: []litellm.Message{
+					litellm.UserText("use the tool"),
+					litellm.Assistant(tc.call),
+				},
+			}, false)
+			if err != nil {
+				t.Fatalf("buildRequest returned error: %v", err)
+			}
+			data, err := json.Marshal(wire)
+			if err != nil {
+				t.Fatalf("marshal wire: %v", err)
+			}
+			var payload struct {
+				Messages []struct {
+					Content []struct {
+						Type  string          `json:"type"`
+						Input json.RawMessage `json:"input"`
+					} `json:"content"`
+				} `json:"messages"`
+			}
+			if err := json.Unmarshal(data, &payload); err != nil {
+				t.Fatalf("unmarshal wire: %v", err)
+			}
+			input := payload.Messages[1].Content[0].Input
+			if string(input) != `{}` {
+				t.Fatalf("tool_use input = %s, want {}\nwire: %s", input, data)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve an empty object for Anthropic `tool_use` input instead of dropping it through `omitempty`
- normalize missing and JSON `null` tool arguments to `{}` before serializing requests
- add regression coverage for missing and explicit empty tool arguments

Anthropic Messages requires every historical `tool_use` content block to carry an `input` object. The previous empty map encoding omitted the field and caused follow-up tool-result requests to fail validation.

## Testing
- `go test ./...`